### PR TITLE
Interface federation proof of concept

### DIFF
--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource.go
@@ -283,7 +283,7 @@ func (p *Planner) ConfigureFetch() plan.FetchConfiguration {
 			ExtractGraphqlResponse:    true,
 			ExtractFederationEntities: p.extractEntities,
 		},
-		BatchConfig:      batchConfig,
+		BatchConfig: batchConfig,
 	}
 }
 
@@ -611,7 +611,13 @@ func (p *Planner) addOnTypeInlineFragments() {
 		}
 	}
 
-	// Share the selection set
+	// Share the selection set between the inline fragments; this only
+	// works if all the inline fragments have exactly the same selections.
+	// Fragments won't have the same selection if the non-upstream operation
+	// itself contains inline fragments. The federation code doesn't (yet)
+	// support inline fragments at the top-level of an upstream operation, but
+	// it'll need to to generally support federation of interface and union
+	// types.
 	selectionSet := p.upstreamOperation.AddSelectionSet()
 
 	for i, onTypeName := range renamedOnTypeNames {


### PR DESCRIPTION
This PR is a proof of concept for interface federation in
graphql-go-tools. It is not meant to be merged. It follows the
implementation strategy outline in jensneuse/graphql-go-tools#328.
Specifically, it uses the first concrete implementation of an interface
as the root type when determining data source ownership of a field. The
field configuration `ForTypeField` method was also updated to have use
the first concrete type. These changes are very hacky, but it helps
identify what needs to change to support federation.

Note that this implementation only works when a selection set is the
same for all concrete types that implement an interface; it doesn't
handle inline fragments with type-specific selections. The federation
code doesn't handle inline fragments at all, actually. This needs to be
fixed.

Related to inline fragments: federation also doesn't support union
types, which require inline fragments for all selection fields.

@csilvers had an interesting idea: expand all interface selections into
inline fragments (which use the concrete types as type conditions)
during the normalization process. This would be done before the
normalization step that merges inline fragments. Then federation and
union support would boil down to teaching the planner configuration
visitor and the GraphQL data source visitor how to handle inline
fragments at the top-level of upstream operations.