### PR TITLE
Add normalization to support abstract field federation

### DIFF
--- a/pkg/ast/ast_interface_type_definition.go
+++ b/pkg/ast/ast_interface_type_definition.go
@@ -118,6 +118,17 @@ func (d *Document) InterfaceTypeDefinitionImplementedByRootNodes(ref int) []Node
 	return nodes
 }
 
+func (d *Document) ConcreteInterfaceImplementationTypeNames(ref int) []string {
+	var typeNames []string
+	for _, node := range d.InterfaceTypeDefinitionImplementedByRootNodes(ref) {
+		if node.Kind != NodeKindObjectTypeDefinition {
+			continue
+		}
+		typeNames = append(typeNames, node.NameString(d))
+	}
+	return typeNames
+}
+
 func (d *Document) AddInterfaceTypeDefinition(definition InterfaceTypeDefinition) (ref int) {
 	d.InterfaceTypeDefinitions = append(d.InterfaceTypeDefinitions, definition)
 	return len(d.InterfaceTypeDefinitions) - 1

--- a/pkg/astnormalization/astnormalization_test.go
+++ b/pkg/astnormalization/astnormalization_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestNormalizeOperation(t *testing.T) {
-
 	run := func(t *testing.T, definition, operation, expectedOutput, variablesInput, expectedVariables string) {
 		t.Helper()
 
@@ -327,7 +326,6 @@ schema {
 }
 
 func BenchmarkAstNormalization(b *testing.B) {
-
 	definition := unsafeparser.ParseGraphqlDocumentString(testDefinition)
 	operation := unsafeparser.ParseGraphqlDocumentString(testOperation)
 	report := operationreport.Report{}
@@ -350,10 +348,12 @@ var mustString = func(str string, err error) string {
 	return str
 }
 
-type registerNormalizeFunc func(walker *astvisitor.Walker)
-type registerNormalizeVariablesFunc func(walker *astvisitor.Walker) *variablesExtractionVisitor
-type registerNormalizeVariablesDefaulValueFunc func(walker *astvisitor.Walker) *variablesDefaultValueExtractionVisitor
-type registerNormalizeDeleteVariablesFunc func(walker *astvisitor.Walker) *deleteUnusedVariablesVisitor
+type (
+	registerNormalizeFunc                     func(walker *astvisitor.Walker)
+	registerNormalizeVariablesFunc            func(walker *astvisitor.Walker) *variablesExtractionVisitor
+	registerNormalizeVariablesDefaulValueFunc func(walker *astvisitor.Walker) *variablesDefaultValueExtractionVisitor
+	registerNormalizeDeleteVariablesFunc      func(walker *astvisitor.Walker) *deleteUnusedVariablesVisitor
+)
 
 var runWithVariablesAssert = func(t *testing.T, registerVisitor func(walker *astvisitor.Walker), definition, operation, operationName, expectedOutput, variablesInput, expectedVariables string, additionalNormalizers ...registerNormalizeFunc) {
 	t.Helper()
@@ -424,7 +424,6 @@ var runWithDeleteUnusedVariables = func(t *testing.T, normalizeFunc registerNorm
 }
 
 var run = func(normalizeFunc registerNormalizeFunc, definition, operation, expectedOutput string) {
-
 	definitionDocument := unsafeparser.ParseGraphqlDocumentString(definition)
 	err := asttransform.MergeDefinitionWithBaseSchema(&definitionDocument)
 	if err != nil {
@@ -453,7 +452,7 @@ var run = func(normalizeFunc registerNormalizeFunc, definition, operation, expec
 }
 
 func runMany(definition, operation, expectedOutput string, normalizeFuncs ...registerNormalizeFunc) {
-	var runManyNormalizers = func(walker *astvisitor.Walker) {
+	runManyNormalizers := func(walker *astvisitor.Walker) {
 		for _, normalizeFunc := range normalizeFuncs {
 			normalizeFunc(walker)
 		}

--- a/pkg/astnormalization/inline_fragment_invalid_deletion.go
+++ b/pkg/astnormalization/inline_fragment_invalid_deletion.go
@@ -1,0 +1,57 @@
+package astnormalization
+
+import (
+	"github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
+)
+
+func deleteInvalidInlineFragments(walker *astvisitor.Walker) {
+	visitor := deleteInvalidInlineFragmentsVisitor{
+		Walker: walker,
+	}
+	walker.RegisterEnterDocumentVisitor(&visitor)
+	walker.RegisterEnterSelectionSetVisitor(&visitor)
+}
+
+type deleteInvalidInlineFragmentsVisitor struct {
+	*astvisitor.Walker
+	operation, definition *ast.Document
+}
+
+func (m *deleteInvalidInlineFragmentsVisitor) EnterDocument(operation, definition *ast.Document) {
+	m.operation = operation
+	m.definition = definition
+}
+
+func (d *deleteInvalidInlineFragmentsVisitor) EnterSelectionSet(ref int) {
+	selections := d.operation.SelectionSets[ref].SelectionRefs
+
+	if len(selections) == 0 {
+		return
+	}
+
+	for index := len(selections) - 1; index >= 0; index -= 1 {
+		if d.operation.Selections[selections[index]].Kind != ast.SelectionKindInlineFragment {
+			continue
+		}
+
+		inlineFragment := d.operation.Selections[selections[index]].Ref
+
+		typeName := d.operation.InlineFragmentTypeConditionName(inlineFragment)
+
+		node, exists := d.definition.Index.FirstNonExtensionNodeByNameBytes(typeName)
+		if !exists {
+			continue
+		}
+
+		// Both the fragment type and enclosing type should be objects at this
+		// point due to interface selection set expansion and inline fragment
+		// abstract type expansion.
+		//
+		// TODO: consider comparing the type names directly instead of calling
+		// NodeFragmentIsAllowedOnNode.
+		if !d.definition.NodeFragmentIsAllowedOnNode(node, d.EnclosingTypeDefinition) {
+			d.operation.RemoveFromSelectionSet(ref, index)
+		}
+	}
+}

--- a/pkg/astnormalization/inline_fragment_invalid_deletion_test.go
+++ b/pkg/astnormalization/inline_fragment_invalid_deletion_test.go
@@ -1,0 +1,27 @@
+package astnormalization
+
+import "testing"
+
+func TestDeleteInvalidInlineFragments(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		run(deleteInvalidInlineFragments, testDefinition, `
+					query testQuery {
+						dog {
+							... on Dog {
+								barkVolume
+							}
+							... on Cat {
+								meowVolume
+							}
+						}
+					}`,
+			`
+					query testQuery {
+						dog {
+							... on Dog {
+								barkVolume
+							}
+						}
+					}`)
+	})
+}

--- a/pkg/astnormalization/inline_fragment_merging_test.go
+++ b/pkg/astnormalization/inline_fragment_merging_test.go
@@ -53,4 +53,26 @@ func TestResolveInlineFragments(t *testing.T) {
 						}
 					}`)
 	})
+	t.Run("sibling fragments", func(t *testing.T) {
+		t.Skip("nice to have, but not strictly necessary")
+		run(mergeInlineFragments, testDefinition, `
+					query testQuery {
+						pet {
+							... on Dog {
+								name
+							}
+							... on Dog {
+								name
+							}
+						}
+					}`,
+			`
+					query testQuery {
+						pet {
+							... on Dog {
+								name
+							}
+						}
+					}`)
+	})
 }

--- a/pkg/astnormalization/inline_fragment_type_expansion.go
+++ b/pkg/astnormalization/inline_fragment_type_expansion.go
@@ -1,0 +1,60 @@
+package astnormalization
+
+import (
+	"github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/asttransform"
+	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
+)
+
+func expandAbstractInlineFragments(walker *astvisitor.Walker) {
+	visitor := expandAbstractInlineFragmentsVisitor{
+		Walker: walker,
+	}
+	walker.RegisterDocumentVisitor(&visitor)
+	walker.RegisterEnterSelectionSetVisitor(&visitor)
+}
+
+type expandAbstractInlineFragmentsVisitor struct {
+	*astvisitor.Walker
+	operation   *ast.Document
+	definition  *ast.Document
+	transformer asttransform.Transformer
+}
+
+func (e *expandAbstractInlineFragmentsVisitor) EnterDocument(operation, definition *ast.Document) {
+	e.transformer.Reset()
+	e.operation = operation
+	e.definition = definition
+}
+
+func (e *expandAbstractInlineFragmentsVisitor) LeaveDocument(operation, definition *ast.Document) {
+	e.transformer.ApplyTransformations(operation)
+}
+
+func (e *expandAbstractInlineFragmentsVisitor) EnterSelectionSet(ref int) {
+	inlineFragmentNode := e.Walker.Ancestors[len(e.Walker.Ancestors)-1]
+
+	if inlineFragmentNode.Kind != ast.NodeKindInlineFragment {
+		return
+	}
+
+	if e.Walker.EnclosingTypeDefinition.Kind != ast.NodeKindInterfaceTypeDefinition &&
+		e.Walker.EnclosingTypeDefinition.Kind != ast.NodeKindUnionTypeDefinition {
+		return
+	}
+
+	parentSelectionSet := e.Walker.Ancestors[len(e.Walker.Ancestors)-2].Ref
+
+	precedence := asttransform.Precedence{
+		Depth: e.Walker.Depth,
+		Order: 0,
+	}
+
+	switch e.Walker.EnclosingTypeDefinition.Kind {
+	case ast.NodeKindInterfaceTypeDefinition:
+		typeNames := e.definition.ConcreteInterfaceImplementationTypeNames(e.Walker.EnclosingTypeDefinition.Ref)
+		e.transformer.ExpandInterfaceInlineFragment(precedence, inlineFragmentNode.Ref, parentSelectionSet, typeNames)
+	case ast.NodeKindUnionTypeDefinition:
+		e.transformer.PromoteUnionInlineFragments(precedence, inlineFragmentNode.Ref, parentSelectionSet)
+	}
+}

--- a/pkg/astnormalization/inline_fragment_type_expansion_test.go
+++ b/pkg/astnormalization/inline_fragment_type_expansion_test.go
@@ -1,0 +1,64 @@
+package astnormalization
+
+import "testing"
+
+func TestExpandInlineFragmentTypes(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		run(expandAbstractInlineFragments, testDefinition, `
+					query testQuery {
+						dog {
+							... on Pet {
+								petName: name
+								... on Pet {
+									nestedPetName: name
+								}
+								... on Cat {
+									catName: name
+								}
+							}
+							... on CatOrDog {
+								... on Dog {
+									catOrDogName: name
+								}
+							}
+							... on Dog {
+								dogName: name
+							}
+						}
+					}`,
+			`
+					query testQuery {
+						dog {
+							... on Dog {
+								petName: name
+								... on Dog {
+									nestedPetName: name
+								}
+								... on Cat {
+									nestedPetName: name
+								}
+								... on Cat {
+									catName: name
+								}
+							}... on Cat {
+								petName: name
+								... on Dog {
+									nestedPetName: name
+								}
+								... on Cat {
+									nestedPetName: name
+								}
+								... on Cat {
+									catName: name
+								}
+							}
+							... on Dog {
+								catOrDogName: name
+							}
+							... on Dog {
+								dogName: name
+							}
+						}
+					}`)
+	})
+}

--- a/pkg/astnormalization/interface_selection_set_expansion.go
+++ b/pkg/astnormalization/interface_selection_set_expansion.go
@@ -1,0 +1,48 @@
+package astnormalization
+
+import (
+	"github.com/jensneuse/graphql-go-tools/pkg/ast"
+	"github.com/jensneuse/graphql-go-tools/pkg/asttransform"
+	"github.com/jensneuse/graphql-go-tools/pkg/astvisitor"
+)
+
+func expandInterfaceSelectionSets(walker *astvisitor.Walker) {
+	visitor := expandInterfaceSelectionSetsVisitor{
+		Walker: walker,
+	}
+	walker.RegisterDocumentVisitor(&visitor)
+	walker.RegisterEnterSelectionSetVisitor(&visitor)
+}
+
+type expandInterfaceSelectionSetsVisitor struct {
+	*astvisitor.Walker
+	operation   *ast.Document
+	definition  *ast.Document
+	transformer asttransform.Transformer
+}
+
+func (e *expandInterfaceSelectionSetsVisitor) EnterDocument(operation, definition *ast.Document) {
+	e.transformer.Reset()
+	e.operation = operation
+	e.definition = definition
+}
+
+func (e *expandInterfaceSelectionSetsVisitor) LeaveDocument(operation, definition *ast.Document) {
+	e.transformer.ApplyTransformations(operation)
+}
+
+func (e *expandInterfaceSelectionSetsVisitor) EnterSelectionSet(ref int) {
+	if e.Walker.EnclosingTypeDefinition.Kind != ast.NodeKindInterfaceTypeDefinition {
+		return
+	}
+	parent := e.Walker.Ancestors[len(e.Walker.Ancestors)-1]
+	if parent.Kind != ast.NodeKindField {
+		return
+	}
+	precedence := asttransform.Precedence{
+		Depth: e.Walker.Depth,
+		Order: 0,
+	}
+	typeNames := e.definition.ConcreteInterfaceImplementationTypeNames(e.Walker.EnclosingTypeDefinition.Ref)
+	e.transformer.ExpandInterfaceSelectionSet(precedence, ref, typeNames)
+}

--- a/pkg/astnormalization/interface_selection_set_expansion_test.go
+++ b/pkg/astnormalization/interface_selection_set_expansion_test.go
@@ -1,0 +1,95 @@
+package astnormalization
+
+import "testing"
+
+func TestExpandInterfaceSelections(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		run(expandInterfaceSelectionSets, testDefinition, `
+					query testQuery {
+						pet {
+							nameOne: name
+							... on Dog {
+								barkVolume
+							}
+							nameTwo: name
+							... on Cat {
+								meowVolume
+							}
+							nameThree: name
+						}
+					}`,
+			`
+					query testQuery {
+						pet {
+							... on Dog {
+								barkVolume
+							}
+							... on Cat {
+								meowVolume
+							}
+							... on Dog {
+								nameOne: name
+								nameTwo: name
+								nameThree: name
+							}
+							... on Cat {
+								nameOne: name
+								nameTwo: name
+								nameThree: name
+							}
+						}
+					}`)
+	})
+
+	t.Run("already expanded", func(t *testing.T) {
+		run(expandInterfaceSelectionSets, testDefinition, `
+					query testQuery {
+						pet {
+							... on Dog {
+								name
+							}
+							... on Cat {
+								name
+							}
+						}
+					}`,
+			`
+					query testQuery {
+						pet {
+							... on Dog {
+								name
+							}
+							... on Cat {
+								name
+							}
+						}
+					}`)
+	})
+
+	t.Run("already expanded with typename", func(t *testing.T) {
+		run(expandInterfaceSelectionSets, testDefinition, `
+					query testQuery {
+						pet {
+							__typename
+							... on Dog {
+								name
+							}
+							... on Cat {
+								name
+							}
+						}
+					}`,
+			`
+					query testQuery {
+						pet {
+							__typename
+							... on Dog {
+								name
+							}
+							... on Cat {
+								name
+							}
+						}
+					}`)
+	})
+}

--- a/pkg/astvalidation/operation_validation_test.go
+++ b/pkg/astvalidation/operation_validation_test.go
@@ -2625,7 +2625,7 @@ func TestExecutionValidation(t *testing.T) {
 											meowVolume
 										}
 									}`,
-							Fragments(), Invalid)
+							Fragments(), Invalid, withDisableNormalization())
 					})
 					t.Run("138 variant", func(t *testing.T) {
 						run(`
@@ -2744,7 +2744,7 @@ func TestExecutionValidation(t *testing.T) {
 									fragment sentientFragment on Sentient {
 										name
 									}`,
-							Fragments(), Invalid)
+							Fragments(), Invalid, withDisableNormalization())
 					})
 				})
 			})

--- a/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
+++ b/pkg/engine/datasource/graphql_datasource/graphql_datasource_test.go
@@ -45,7 +45,7 @@ func TestGraphQLDataSource(t *testing.T) {
 				Fetch: &resolve.SingleFetch{
 					DataSource: &Source{},
 					BufferId:   0,
-					Input:      `{"method":"POST","url":"https://swapi.com/graphql","header":{"Authorization":["$$1$$"],"Invalid-Template":["{{ request.headers.Authorization }}"]},"body":{"query":"query($id: ID!){droid(id: $id){name aliased: name friends {name} primaryFunction} hero {name} stringList nestedStringList}","variables":{"id":$$0$$}}}`,
+					Input:      `{"method":"POST","url":"https://swapi.com/graphql","header":{"Authorization":["$$1$$"],"Invalid-Template":["{{ request.headers.Authorization }}"]},"body":{"query":"query($id: ID!){droid(id: $id){name aliased: name friends {__typename ... on Human {name} ... on Droid {name}} primaryFunction} hero {__typename ... on Human {name} ... on Droid {name}} stringList nestedStringList}","variables":{"id":$$0$$}}}`,
 					Variables: resolve.NewVariables(
 						&resolve.ContextVariable{
 							Path:     []string{"id"},
@@ -109,9 +109,21 @@ func TestGraphQLDataSource(t *testing.T) {
 														Path: []string{"name"},
 													},
 													Position: resolve.Position{
-														Line:   7,
-														Column: 6,
+														Line:   0,
+														Column: 0,
 													},
+													OnTypeName: []byte("Human"),
+												},
+												{
+													Name: []byte("name"),
+													Value: &resolve.String{
+														Path: []string{"name"},
+													},
+													Position: resolve.Position{
+														Line:   0,
+														Column: 0,
+													},
+													OnTypeName: []byte("Droid"),
 												},
 											},
 										},
@@ -148,9 +160,21 @@ func TestGraphQLDataSource(t *testing.T) {
 										Path: []string{"name"},
 									},
 									Position: resolve.Position{
-										Line:   12,
-										Column: 5,
+										Line:   0,
+										Column: 0,
 									},
+									OnTypeName: []byte("Human"),
+								},
+								{
+									Name: []byte("name"),
+									Value: &resolve.String{
+										Path: []string{"name"},
+									},
+									Position: resolve.Position{
+										Line:   0,
+										Column: 0,
+									},
+									OnTypeName: []byte("Droid"),
 								},
 							},
 						},
@@ -258,9 +282,9 @@ func TestGraphQLDataSource(t *testing.T) {
 		Response: &resolve.GraphQLResponse{
 			Data: &resolve.Object{
 				Fetch: &resolve.SingleFetch{
-					DataSource: &Source{},
-					BufferId:   0,
-					Input:      `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"{user {id displayName}}"}}`,
+					DataSource:            &Source{},
+					BufferId:              0,
+					Input:                 `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"{user {__typename ... on RegisteredUser {id displayName}}}"}}`,
 					DataSourceIdentifier:  []byte("graphql_datasource.Source"),
 					ProcessResponseConfig: resolve.ProcessResponseConfig{ExtractGraphqlResponse: true},
 				},
@@ -283,9 +307,10 @@ func TestGraphQLDataSource(t *testing.T) {
 										Path: []string{"id"},
 									},
 									Position: resolve.Position{
-										Line:   4,
-										Column: 5,
+										Line:   0,
+										Column: 0,
 									},
+									OnTypeName: []byte("RegisteredUser"),
 								},
 								{
 									Name: []byte("displayName"),
@@ -293,9 +318,10 @@ func TestGraphQLDataSource(t *testing.T) {
 										Path: []string{"displayName"},
 									},
 									Position: resolve.Position{
-										Line:   5,
-										Column: 5,
+										Line:   0,
+										Column: 0,
 									},
+									OnTypeName: []byte("RegisteredUser"),
 								},
 							},
 						},
@@ -315,11 +341,11 @@ func TestGraphQLDataSource(t *testing.T) {
 				ChildNodes: []plan.TypeField{
 					{
 						TypeName:   "User",
-						FieldNames: []string{"id", "displayName","isLoggedIn"},
+						FieldNames: []string{"id", "displayName", "isLoggedIn"},
 					},
 					{
 						TypeName:   "RegisteredUser",
-						FieldNames: []string{"id", "displayName","isLoggedIn"},
+						FieldNames: []string{"id", "displayName", "isLoggedIn"},
 					},
 				},
 				Factory: &Factory{},
@@ -343,14 +369,14 @@ func TestGraphQLDataSource(t *testing.T) {
 		Response: &resolve.GraphQLResponse{
 			Data: &resolve.Object{
 				Fetch: &resolve.SingleFetch{
-					DataSource: &Source{},
-					BufferId:   0,
-					Input:      `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"query($skip: Boolean!){user {id displayName @skip(if: $skip)}}","variables":{"skip":$$0$$}}}`,
+					DataSource:            &Source{},
+					BufferId:              0,
+					Input:                 `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"query($skip: Boolean!){user {__typename ... on RegisteredUser {id displayName @skip(if: $skip)}}}","variables":{"skip":$$0$$}}}`,
 					DataSourceIdentifier:  []byte("graphql_datasource.Source"),
 					ProcessResponseConfig: resolve.ProcessResponseConfig{ExtractGraphqlResponse: true},
 					Variables: resolve.NewVariables(
 						&resolve.ContextVariable{
-							Path: []string{"skip"},
+							Path:     []string{"skip"},
 							Renderer: resolve.NewJSONVariableRendererWithValidation(`{"type":"boolean"}`),
 						},
 					),
@@ -374,9 +400,10 @@ func TestGraphQLDataSource(t *testing.T) {
 										Path: []string{"id"},
 									},
 									Position: resolve.Position{
-										Line:   4,
-										Column: 5,
+										Line:   0,
+										Column: 0,
 									},
+									OnTypeName: []byte("RegisteredUser"),
 								},
 								{
 									Name: []byte("displayName"),
@@ -384,11 +411,12 @@ func TestGraphQLDataSource(t *testing.T) {
 										Path: []string{"displayName"},
 									},
 									Position: resolve.Position{
-										Line:   5,
-										Column: 5,
+										Line:   0,
+										Column: 0,
 									},
 									SkipDirectiveDefined: true,
 									SkipVariableName:     "skip",
+									OnTypeName:           []byte("RegisteredUser"),
 								},
 							},
 						},
@@ -408,11 +436,11 @@ func TestGraphQLDataSource(t *testing.T) {
 				ChildNodes: []plan.TypeField{
 					{
 						TypeName:   "User",
-						FieldNames: []string{"id", "displayName","isLoggedIn"},
+						FieldNames: []string{"id", "displayName", "isLoggedIn"},
 					},
 					{
 						TypeName:   "RegisteredUser",
-						FieldNames: []string{"id", "displayName","isLoggedIn"},
+						FieldNames: []string{"id", "displayName", "isLoggedIn"},
 					},
 				},
 				Factory: &Factory{},
@@ -438,14 +466,14 @@ func TestGraphQLDataSource(t *testing.T) {
 		Response: &resolve.GraphQLResponse{
 			Data: &resolve.Object{
 				Fetch: &resolve.SingleFetch{
-					DataSource: &Source{},
-					BufferId:   0,
-					Input:      `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"query($skip: Boolean!){user {... @skip(if: $skip){id displayName}}}","variables":{"skip":$$0$$}}}`,
+					DataSource:            &Source{},
+					BufferId:              0,
+					Input:                 `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"query($skip: Boolean!){user {__typename ... on RegisteredUser @skip(if: $skip){id displayName}}}","variables":{"skip":$$0$$}}}`,
 					DataSourceIdentifier:  []byte("graphql_datasource.Source"),
 					ProcessResponseConfig: resolve.ProcessResponseConfig{ExtractGraphqlResponse: true},
 					Variables: resolve.NewVariables(
 						&resolve.ContextVariable{
-							Path: []string{"skip"},
+							Path:     []string{"skip"},
 							Renderer: resolve.NewJSONVariableRendererWithValidation(`{"type":"boolean"}`),
 						},
 					),
@@ -469,11 +497,12 @@ func TestGraphQLDataSource(t *testing.T) {
 										Path: []string{"id"},
 									},
 									Position: resolve.Position{
-										Line:   5,
-										Column: 6,
+										Line:   0,
+										Column: 0,
 									},
 									SkipDirectiveDefined: true,
 									SkipVariableName:     "skip",
+									OnTypeName:           []byte("RegisteredUser"),
 								},
 								{
 									Name: []byte("displayName"),
@@ -481,11 +510,12 @@ func TestGraphQLDataSource(t *testing.T) {
 										Path: []string{"displayName"},
 									},
 									Position: resolve.Position{
-										Line:   6,
-										Column: 6,
+										Line:   0,
+										Column: 0,
 									},
 									SkipDirectiveDefined: true,
 									SkipVariableName:     "skip",
+									OnTypeName:           []byte("RegisteredUser"),
 								},
 							},
 						},
@@ -505,11 +535,11 @@ func TestGraphQLDataSource(t *testing.T) {
 				ChildNodes: []plan.TypeField{
 					{
 						TypeName:   "User",
-						FieldNames: []string{"id", "displayName","isLoggedIn"},
+						FieldNames: []string{"id", "displayName", "isLoggedIn"},
 					},
 					{
 						TypeName:   "RegisteredUser",
-						FieldNames: []string{"id", "displayName","isLoggedIn"},
+						FieldNames: []string{"id", "displayName", "isLoggedIn"},
 					},
 				},
 				Factory: &Factory{},
@@ -535,14 +565,14 @@ func TestGraphQLDataSource(t *testing.T) {
 		Response: &resolve.GraphQLResponse{
 			Data: &resolve.Object{
 				Fetch: &resolve.SingleFetch{
-					DataSource: &Source{},
-					BufferId:   0,
-					Input:      `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"query($include: Boolean!){user {... @include(if: $include){id displayName}}}","variables":{"include":$$0$$}}}`,
+					DataSource:            &Source{},
+					BufferId:              0,
+					Input:                 `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"query($include: Boolean!){user {__typename ... on RegisteredUser @include(if: $include){id displayName}}}","variables":{"include":$$0$$}}}`,
 					DataSourceIdentifier:  []byte("graphql_datasource.Source"),
 					ProcessResponseConfig: resolve.ProcessResponseConfig{ExtractGraphqlResponse: true},
 					Variables: resolve.NewVariables(
 						&resolve.ContextVariable{
-							Path: []string{"include"},
+							Path:     []string{"include"},
 							Renderer: resolve.NewJSONVariableRendererWithValidation(`{"type":"boolean"}`),
 						},
 					),
@@ -566,11 +596,12 @@ func TestGraphQLDataSource(t *testing.T) {
 										Path: []string{"id"},
 									},
 									Position: resolve.Position{
-										Line:   5,
-										Column: 6,
+										Line:   0,
+										Column: 0,
 									},
 									IncludeDirectiveDefined: true,
 									IncludeVariableName:     "include",
+									OnTypeName:              []byte("RegisteredUser"),
 								},
 								{
 									Name: []byte("displayName"),
@@ -578,11 +609,12 @@ func TestGraphQLDataSource(t *testing.T) {
 										Path: []string{"displayName"},
 									},
 									Position: resolve.Position{
-										Line:   6,
-										Column: 6,
+										Line:   0,
+										Column: 0,
 									},
 									IncludeDirectiveDefined: true,
 									IncludeVariableName:     "include",
+									OnTypeName:              []byte("RegisteredUser"),
 								},
 							},
 						},
@@ -602,11 +634,11 @@ func TestGraphQLDataSource(t *testing.T) {
 				ChildNodes: []plan.TypeField{
 					{
 						TypeName:   "User",
-						FieldNames: []string{"id", "displayName","isLoggedIn"},
+						FieldNames: []string{"id", "displayName", "isLoggedIn"},
 					},
 					{
 						TypeName:   "RegisteredUser",
-						FieldNames: []string{"id", "displayName","isLoggedIn"},
+						FieldNames: []string{"id", "displayName", "isLoggedIn"},
 					},
 				},
 				Factory: &Factory{},
@@ -630,9 +662,9 @@ func TestGraphQLDataSource(t *testing.T) {
 		Response: &resolve.GraphQLResponse{
 			Data: &resolve.Object{
 				Fetch: &resolve.SingleFetch{
-					DataSource: &Source{},
-					BufferId:   0,
-					Input:      `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"{user {id}}"}}`,
+					DataSource:            &Source{},
+					BufferId:              0,
+					Input:                 `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"{user {__typename ... on RegisteredUser {id}}}"}}`,
 					DataSourceIdentifier:  []byte("graphql_datasource.Source"),
 					ProcessResponseConfig: resolve.ProcessResponseConfig{ExtractGraphqlResponse: true},
 				},
@@ -655,9 +687,10 @@ func TestGraphQLDataSource(t *testing.T) {
 										Path: []string{"id"},
 									},
 									Position: resolve.Position{
-										Line:   4,
-										Column: 5,
+										Line:   0,
+										Column: 0,
 									},
+									OnTypeName: []byte("RegisteredUser"),
 								},
 							},
 						},
@@ -677,11 +710,11 @@ func TestGraphQLDataSource(t *testing.T) {
 				ChildNodes: []plan.TypeField{
 					{
 						TypeName:   "User",
-						FieldNames: []string{"id", "displayName","isLoggedIn"},
+						FieldNames: []string{"id", "displayName", "isLoggedIn"},
 					},
 					{
 						TypeName:   "RegisteredUser",
-						FieldNames: []string{"id", "displayName","isLoggedIn"},
+						FieldNames: []string{"id", "displayName", "isLoggedIn"},
 					},
 				},
 				Factory: &Factory{},
@@ -705,9 +738,9 @@ func TestGraphQLDataSource(t *testing.T) {
 		Response: &resolve.GraphQLResponse{
 			Data: &resolve.Object{
 				Fetch: &resolve.SingleFetch{
-					DataSource: &Source{},
-					BufferId:   0,
-					Input:      `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"{user {id displayName}}"}}`,
+					DataSource:            &Source{},
+					BufferId:              0,
+					Input:                 `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"{user {__typename ... on RegisteredUser {id displayName}}}"}}`,
 					DataSourceIdentifier:  []byte("graphql_datasource.Source"),
 					ProcessResponseConfig: resolve.ProcessResponseConfig{ExtractGraphqlResponse: true},
 				},
@@ -730,9 +763,10 @@ func TestGraphQLDataSource(t *testing.T) {
 										Path: []string{"id"},
 									},
 									Position: resolve.Position{
-										Line:   4,
-										Column: 5,
+										Line:   0,
+										Column: 0,
 									},
+									OnTypeName: []byte("RegisteredUser"),
 								},
 								{
 									Name: []byte("displayName"),
@@ -740,9 +774,10 @@ func TestGraphQLDataSource(t *testing.T) {
 										Path: []string{"displayName"},
 									},
 									Position: resolve.Position{
-										Line:   5,
-										Column: 5,
+										Line:   0,
+										Column: 0,
 									},
+									OnTypeName: []byte("RegisteredUser"),
 								},
 							},
 						},
@@ -762,11 +797,11 @@ func TestGraphQLDataSource(t *testing.T) {
 				ChildNodes: []plan.TypeField{
 					{
 						TypeName:   "User",
-						FieldNames: []string{"id", "displayName","isLoggedIn"},
+						FieldNames: []string{"id", "displayName", "isLoggedIn"},
 					},
 					{
 						TypeName:   "RegisteredUser",
-						FieldNames: []string{"id", "displayName","isLoggedIn"},
+						FieldNames: []string{"id", "displayName", "isLoggedIn"},
 					},
 				},
 				Factory: &Factory{},
@@ -790,14 +825,14 @@ func TestGraphQLDataSource(t *testing.T) {
 		Response: &resolve.GraphQLResponse{
 			Data: &resolve.Object{
 				Fetch: &resolve.SingleFetch{
-					DataSource: &Source{},
-					BufferId:   0,
-					Input:      `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"query($include: Boolean!){user {id displayName @include(if: $include)}}","variables":{"include":$$0$$}}}`,
+					DataSource:            &Source{},
+					BufferId:              0,
+					Input:                 `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"query($include: Boolean!){user {__typename ... on RegisteredUser {id displayName @include(if: $include)}}}","variables":{"include":$$0$$}}}`,
 					DataSourceIdentifier:  []byte("graphql_datasource.Source"),
 					ProcessResponseConfig: resolve.ProcessResponseConfig{ExtractGraphqlResponse: true},
 					Variables: resolve.NewVariables(
 						&resolve.ContextVariable{
-							Path: []string{"include"},
+							Path:     []string{"include"},
 							Renderer: resolve.NewJSONVariableRendererWithValidation(`{"type":"boolean"}`),
 						},
 					),
@@ -821,9 +856,10 @@ func TestGraphQLDataSource(t *testing.T) {
 										Path: []string{"id"},
 									},
 									Position: resolve.Position{
-										Line:   4,
-										Column: 5,
+										Line:   0,
+										Column: 0,
 									},
+									OnTypeName: []byte("RegisteredUser"),
 								},
 								{
 									Name: []byte("displayName"),
@@ -831,11 +867,12 @@ func TestGraphQLDataSource(t *testing.T) {
 										Path: []string{"displayName"},
 									},
 									Position: resolve.Position{
-										Line:   5,
-										Column: 5,
+										Line:   0,
+										Column: 0,
 									},
 									IncludeDirectiveDefined: true,
 									IncludeVariableName:     "include",
+									OnTypeName:              []byte("RegisteredUser"),
 								},
 							},
 						},
@@ -855,11 +892,11 @@ func TestGraphQLDataSource(t *testing.T) {
 				ChildNodes: []plan.TypeField{
 					{
 						TypeName:   "User",
-						FieldNames: []string{"id", "displayName","isLoggedIn"},
+						FieldNames: []string{"id", "displayName", "isLoggedIn"},
 					},
 					{
 						TypeName:   "RegisteredUser",
-						FieldNames: []string{"id", "displayName","isLoggedIn"},
+						FieldNames: []string{"id", "displayName", "isLoggedIn"},
 					},
 				},
 				Factory: &Factory{},
@@ -883,9 +920,9 @@ func TestGraphQLDataSource(t *testing.T) {
 		Response: &resolve.GraphQLResponse{
 			Data: &resolve.Object{
 				Fetch: &resolve.SingleFetch{
-					DataSource: &Source{},
-					BufferId:   0,
-					Input:      `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"{user {id displayName}}"}}`,
+					DataSource:            &Source{},
+					BufferId:              0,
+					Input:                 `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"{user {__typename ... on RegisteredUser {id displayName}}}"}}`,
 					DataSourceIdentifier:  []byte("graphql_datasource.Source"),
 					ProcessResponseConfig: resolve.ProcessResponseConfig{ExtractGraphqlResponse: true},
 				},
@@ -908,9 +945,10 @@ func TestGraphQLDataSource(t *testing.T) {
 										Path: []string{"id"},
 									},
 									Position: resolve.Position{
-										Line:   4,
-										Column: 5,
+										Line:   0,
+										Column: 0,
 									},
+									OnTypeName: []byte("RegisteredUser"),
 								},
 								{
 									Name: []byte("displayName"),
@@ -918,9 +956,10 @@ func TestGraphQLDataSource(t *testing.T) {
 										Path: []string{"displayName"},
 									},
 									Position: resolve.Position{
-										Line:   5,
-										Column: 5,
+										Line:   0,
+										Column: 0,
 									},
+									OnTypeName: []byte("RegisteredUser"),
 								},
 							},
 						},
@@ -940,11 +979,11 @@ func TestGraphQLDataSource(t *testing.T) {
 				ChildNodes: []plan.TypeField{
 					{
 						TypeName:   "User",
-						FieldNames: []string{"id", "displayName","isLoggedIn"},
+						FieldNames: []string{"id", "displayName", "isLoggedIn"},
 					},
 					{
 						TypeName:   "RegisteredUser",
-						FieldNames: []string{"id", "displayName","isLoggedIn"},
+						FieldNames: []string{"id", "displayName", "isLoggedIn"},
 					},
 				},
 				Factory: &Factory{},
@@ -968,9 +1007,9 @@ func TestGraphQLDataSource(t *testing.T) {
 		Response: &resolve.GraphQLResponse{
 			Data: &resolve.Object{
 				Fetch: &resolve.SingleFetch{
-					DataSource: &Source{},
-					BufferId:   0,
-					Input:      `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"{user {id}}"}}`,
+					DataSource:            &Source{},
+					BufferId:              0,
+					Input:                 `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"{user {__typename ... on RegisteredUser {id}}}"}}`,
 					DataSourceIdentifier:  []byte("graphql_datasource.Source"),
 					ProcessResponseConfig: resolve.ProcessResponseConfig{ExtractGraphqlResponse: true},
 				},
@@ -993,106 +1032,8 @@ func TestGraphQLDataSource(t *testing.T) {
 										Path: []string{"id"},
 									},
 									Position: resolve.Position{
-										Line:   4,
-										Column: 5,
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}, plan.Configuration{
-		DataSources: []plan.DataSourceConfiguration{
-			{
-				RootNodes: []plan.TypeField{
-					{
-						TypeName:   "Query",
-						FieldNames: []string{"user"},
-					},
-				},
-				ChildNodes: []plan.TypeField{
-					{
-						TypeName:   "User",
-						FieldNames: []string{"id", "displayName","isLoggedIn"},
-					},
-					{
-						TypeName:   "RegisteredUser",
-						FieldNames: []string{"id", "displayName","isLoggedIn"},
-					},
-				},
-				Factory: &Factory{},
-				Custom: ConfigJson(Configuration{
-					Fetch: FetchConfiguration{
-						URL: "https://swapi.com/graphql",
-					},
-				}),
-			},
-		},
-		Fields: []plan.FieldConfiguration{},
-	}))
-	t.Run("selections on interface type with object type interface", RunTest(interfaceSelectionSchema, `
-		query MyQuery {
-			user {
-				id
-				displayName
-				... on RegisteredUser {
-					hasVerifiedEmail
-				}
-			}
-		}
-	`, "MyQuery", &plan.SynchronousResponsePlan{
-		Response: &resolve.GraphQLResponse{
-			Data: &resolve.Object{
-				Fetch: &resolve.SingleFetch{
-					DataSource: &Source{},
-					BufferId:   0,
-					Input:      `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"{user {id displayName __typename ... on RegisteredUser {hasVerifiedEmail}}}"}}`,
-					DataSourceIdentifier:  []byte("graphql_datasource.Source"),
-					ProcessResponseConfig: resolve.ProcessResponseConfig{ExtractGraphqlResponse: true},
-				},
-				Fields: []*resolve.Field{
-					{
-						HasBuffer: true,
-						BufferID:  0,
-						Name:      []byte("user"),
-						Position: resolve.Position{
-							Line:   3,
-							Column: 4,
-						},
-						Value: &resolve.Object{
-							Path:     []string{"user"},
-							Nullable: true,
-							Fields: []*resolve.Field{
-								{
-									Name: []byte("id"),
-									Value: &resolve.String{
-										Path: []string{"id"},
-									},
-									Position: resolve.Position{
-										Line:   4,
-										Column: 5,
-									},
-								},
-								{
-									Name: []byte("displayName"),
-									Value: &resolve.String{
-										Path: []string{"displayName"},
-									},
-									Position: resolve.Position{
-										Line:   5,
-										Column: 5,
-									},
-								},
-								{
-									Name: []byte("hasVerifiedEmail"),
-									Value: &resolve.Boolean{
-										Path: []string{"hasVerifiedEmail"},
-									},
-									Position: resolve.Position{
-										Line:   7,
-										Column: 6,
+										Line:   0,
+										Column: 0,
 									},
 									OnTypeName: []byte("RegisteredUser"),
 								},
@@ -1114,11 +1055,114 @@ func TestGraphQLDataSource(t *testing.T) {
 				ChildNodes: []plan.TypeField{
 					{
 						TypeName:   "User",
-						FieldNames: []string{"id", "displayName","isLoggedIn"},
+						FieldNames: []string{"id", "displayName", "isLoggedIn"},
 					},
 					{
 						TypeName:   "RegisteredUser",
-						FieldNames: []string{"id", "displayName","isLoggedIn","hasVerifiedEmail"},
+						FieldNames: []string{"id", "displayName", "isLoggedIn"},
+					},
+				},
+				Factory: &Factory{},
+				Custom: ConfigJson(Configuration{
+					Fetch: FetchConfiguration{
+						URL: "https://swapi.com/graphql",
+					},
+				}),
+			},
+		},
+		Fields: []plan.FieldConfiguration{},
+	}))
+	// Note: this test shows a case where sibling fragments *could* be combined
+	// but currently aren't.
+	t.Run("selections on interface type with object type interface", RunTest(interfaceSelectionSchema, `
+		query MyQuery {
+			user {
+				id
+				displayName
+				... on RegisteredUser {
+					hasVerifiedEmail
+				}
+			}
+		}
+	`, "MyQuery", &plan.SynchronousResponsePlan{
+		Response: &resolve.GraphQLResponse{
+			Data: &resolve.Object{
+				Fetch: &resolve.SingleFetch{
+					DataSource:            &Source{},
+					BufferId:              0,
+					Input:                 `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"{user {__typename ... on RegisteredUser {hasVerifiedEmail} ... on RegisteredUser {id displayName}}}"}}`,
+					DataSourceIdentifier:  []byte("graphql_datasource.Source"),
+					ProcessResponseConfig: resolve.ProcessResponseConfig{ExtractGraphqlResponse: true},
+				},
+				Fields: []*resolve.Field{
+					{
+						HasBuffer: true,
+						BufferID:  0,
+						Name:      []byte("user"),
+						Position: resolve.Position{
+							Line:   3,
+							Column: 4,
+						},
+						Value: &resolve.Object{
+							Path:     []string{"user"},
+							Nullable: true,
+							Fields: []*resolve.Field{
+								{
+									Name: []byte("hasVerifiedEmail"),
+									Value: &resolve.Boolean{
+										Path: []string{"hasVerifiedEmail"},
+									},
+									Position: resolve.Position{
+										Line:   7,
+										Column: 6,
+									},
+									OnTypeName: []byte("RegisteredUser"),
+								},
+								{
+									Name: []byte("id"),
+									Value: &resolve.String{
+										Path: []string{"id"},
+									},
+									Position: resolve.Position{
+										Line:   0,
+										Column: 0,
+									},
+									OnTypeName: []byte("RegisteredUser"),
+								},
+								{
+									Name: []byte("displayName"),
+									Value: &resolve.String{
+										Path: []string{"displayName"},
+									},
+									Position: resolve.Position{
+										Line:   0,
+										Column: 0,
+									},
+									OnTypeName: []byte("RegisteredUser"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, plan.Configuration{
+		DataSources: []plan.DataSourceConfiguration{
+			{
+				RootNodes: []plan.TypeField{
+					{
+						TypeName:   "Query",
+						FieldNames: []string{"user"},
+					},
+				},
+				ChildNodes: []plan.TypeField{
+					{
+						TypeName:   "User",
+						FieldNames: []string{"id", "displayName", "isLoggedIn"},
+					},
+					{
+						TypeName:   "RegisteredUser",
+						FieldNames: []string{"id", "displayName", "isLoggedIn", "hasVerifiedEmail"},
 					},
 				},
 				Factory: &Factory{},
@@ -1158,7 +1202,7 @@ func TestGraphQLDataSource(t *testing.T) {
 				Fetch: &resolve.SingleFetch{
 					DataSource: &Source{},
 					BufferId:   0,
-					Input:      `{"method":"POST","url":"https://swapi.com/graphql","header":{"Authorization":["$$2$$"],"Invalid-Template":["{{ request.headers.Authorization }}"]},"body":{"query":"query($id: ID!, $heroName: String!){droid(id: $id){name aliased: name friends {name} primaryFunction} hero {name} search(name: $heroName){__typename ... on Droid {primaryFunction}} stringList nestedStringList}","variables":{"heroName":$$1$$,"id":$$0$$}}}`,
+					Input:      `{"method":"POST","url":"https://swapi.com/graphql","header":{"Authorization":["$$2$$"],"Invalid-Template":["{{ request.headers.Authorization }}"]},"body":{"query":"query($id: ID!, $heroName: String!){droid(id: $id){name aliased: name friends {__typename ... on Human {name} ... on Droid {name}} primaryFunction} hero {__typename ... on Human {name} ... on Droid {name}} search(name: $heroName){__typename ... on Droid {primaryFunction}} stringList nestedStringList}","variables":{"heroName":$$1$$,"id":$$0$$}}}`,
 					Variables: resolve.NewVariables(
 						&resolve.ContextVariable{
 							Path:     []string{"id"},
@@ -1226,9 +1270,21 @@ func TestGraphQLDataSource(t *testing.T) {
 														Path: []string{"name"},
 													},
 													Position: resolve.Position{
-														Line:   7,
-														Column: 6,
+														Line:   0,
+														Column: 0,
 													},
+													OnTypeName: []byte("Human"),
+												},
+												{
+													Name: []byte("name"),
+													Value: &resolve.String{
+														Path: []string{"name"},
+													},
+													Position: resolve.Position{
+														Line:   0,
+														Column: 0,
+													},
+													OnTypeName: []byte("Droid"),
 												},
 											},
 										},
@@ -1269,9 +1325,25 @@ func TestGraphQLDataSource(t *testing.T) {
 										},
 									},
 									Position: resolve.Position{
-										Line:   12,
-										Column: 5,
+										Line:   0,
+										Column: 0,
 									},
+									OnTypeName: []byte("Human"),
+								},
+								{
+									Name: []byte("name"),
+									Value: &resolve.String{
+										Path: []string{"name"},
+										Export: &resolve.FieldExport{
+											Path:     []string{"heroName"},
+											AsString: true,
+										},
+									},
+									Position: resolve.Position{
+										Line:   0,
+										Column: 0,
+									},
+									OnTypeName: []byte("Droid"),
 								},
 							},
 						},
@@ -1448,7 +1520,7 @@ func TestGraphQLDataSource(t *testing.T) {
 				Fetch: &resolve.SingleFetch{
 					DataSource: &Source{},
 					BufferId:   0,
-					Input:      `{"method":"POST","url":"https://swapi.com/graphql","header":{"Authorization":["$$3$$"],"Invalid-Template":["{{ request.headers.Authorization }}"]},"body":{"query":"query($id: ID!, $input: SearchInput! @onVariable, $options: JSON)@onOperation {api_droid: droid(id: $id){name @format aliased: name friends {name} primaryFunction} api_hero: hero {name __typename ... on Human {height}} api_stringList: stringList renamed: nestedStringList api_search: search {__typename ... on Droid {primaryFunction}} api_searchWithInput: searchWithInput(input: $input){__typename ... on Droid {primaryFunction}} withOptions: searchWithInput(input: {options: $options}){__typename ... on Droid {primaryFunction}}}","variables":{"options":$$2$$,"input":$$1$$,"id":$$0$$}}}`,
+					Input:      `{"method":"POST","url":"https://swapi.com/graphql","header":{"Authorization":["$$3$$"],"Invalid-Template":["{{ request.headers.Authorization }}"]},"body":{"query":"query($id: ID!, $input: SearchInput! @onVariable, $options: JSON)@onOperation {api_droid: droid(id: $id){name @format aliased: name friends {__typename ... on Human {name} ... on Droid {name}} primaryFunction} api_hero: hero {__typename ... on Human {height} ... on Human {name} ... on Droid {name}} api_stringList: stringList renamed: nestedStringList api_search: search {__typename ... on Droid {primaryFunction}} api_searchWithInput: searchWithInput(input: $input){__typename ... on Droid {primaryFunction}} withOptions: searchWithInput(input: {options: $options}){__typename ... on Droid {primaryFunction}}}","variables":{"options":$$2$$,"input":$$1$$,"id":$$0$$}}}`,
 					Variables: resolve.NewVariables(
 						&resolve.ContextVariable{
 							Path:     []string{"id"},
@@ -1520,9 +1592,21 @@ func TestGraphQLDataSource(t *testing.T) {
 														Path: []string{"name"},
 													},
 													Position: resolve.Position{
-														Line:   7,
-														Column: 6,
+														Line:   0,
+														Column: 0,
 													},
+													OnTypeName: []byte("Human"),
+												},
+												{
+													Name: []byte("name"),
+													Value: &resolve.String{
+														Path: []string{"name"},
+													},
+													Position: resolve.Position{
+														Line:   0,
+														Column: 0,
+													},
+													OnTypeName: []byte("Droid"),
 												},
 											},
 										},
@@ -1554,16 +1638,6 @@ func TestGraphQLDataSource(t *testing.T) {
 							Nullable: true,
 							Fields: []*resolve.Field{
 								{
-									Name: []byte("name"),
-									Value: &resolve.String{
-										Path: []string{"name"},
-									},
-									Position: resolve.Position{
-										Line:   12,
-										Column: 5,
-									},
-								},
-								{
 									Name: []byte("height"),
 									Value: &resolve.String{
 										Path: []string{"height"},
@@ -1573,6 +1647,28 @@ func TestGraphQLDataSource(t *testing.T) {
 										Column: 6,
 									},
 									OnTypeName: []byte("Human"),
+								},
+								{
+									Name: []byte("name"),
+									Value: &resolve.String{
+										Path: []string{"name"},
+									},
+									Position: resolve.Position{
+										Line:   0,
+										Column: 0,
+									},
+									OnTypeName: []byte("Human"),
+								},
+								{
+									Name: []byte("name"),
+									Value: &resolve.String{
+										Path: []string{"name"},
+									},
+									Position: resolve.Position{
+										Line:   0,
+										Column: 0,
+									},
+									OnTypeName: []byte("Droid"),
 								},
 							},
 						},
@@ -2150,7 +2246,7 @@ func TestGraphQLDataSource(t *testing.T) {
 				Data: &resolve.Object{
 					Fetch: &resolve.SingleFetch{
 						BufferId:   0,
-						Input:      `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"query($birthdate: Date!){heroByBirthdate(birthdate: $birthdate){name}}","variables":{"birthdate":$$0$$}}}`,
+						Input:      `{"method":"POST","url":"https://swapi.com/graphql","body":{"query":"query($birthdate: Date!){heroByBirthdate(birthdate: $birthdate){__typename ... on Human {name} ... on Droid {name}}}","variables":{"birthdate":$$0$$}}}`,
 						DataSource: &Source{},
 						Variables: resolve.NewVariables(
 							&resolve.ContextVariable{
@@ -2175,9 +2271,22 @@ func TestGraphQLDataSource(t *testing.T) {
 											Nullable: false,
 										},
 										Position: resolve.Position{
-											Line:   4,
-											Column: 5,
+											Line:   0,
+											Column: 0,
 										},
+										OnTypeName: []byte("Human"),
+									},
+									{
+										Name: []byte("name"),
+										Value: &resolve.String{
+											Path:     []string{"name"},
+											Nullable: false,
+										},
+										Position: resolve.Position{
+											Line:   0,
+											Column: 0,
+										},
+										OnTypeName: []byte("Droid"),
 									},
 								},
 							},

--- a/pkg/engine/plan/plan_test.go
+++ b/pkg/engine/plan/plan_test.go
@@ -54,7 +54,6 @@ func TestPlanner_Plan(t *testing.T) {
 			}
 
 			assert.Equal(t, toJson(expectedPlan), toJson(plan))
-
 		}
 	}
 
@@ -139,9 +138,21 @@ func TestPlanner_Plan(t *testing.T) {
 														Path: []string{"name"},
 													},
 													Position: resolve.Position{
-														Line:   7,
-														Column: 6,
+														Line:   0,
+														Column: 0,
 													},
+													OnTypeName: []byte("Human"),
+												},
+												{
+													Name: []byte("name"),
+													Value: &resolve.String{
+														Path: []string{"name"},
+													},
+													Position: resolve.Position{
+														Line:   0,
+														Column: 0,
+													},
+													OnTypeName: []byte("Droid"),
 												},
 											},
 										},
@@ -168,9 +179,21 @@ func TestPlanner_Plan(t *testing.T) {
 														Path: []string{"name"},
 													},
 													Position: resolve.Position{
-														Line:   10,
-														Column: 6,
+														Line:   0,
+														Column: 0,
 													},
+													OnTypeName: []byte("Human"),
+												},
+												{
+													Name: []byte("name"),
+													Value: &resolve.String{
+														Path: []string{"name"},
+													},
+													Position: resolve.Position{
+														Line:   0,
+														Column: 0,
+													},
+													OnTypeName: []byte("Droid"),
 												},
 											},
 										},
@@ -287,7 +310,6 @@ func TestPlanner_Plan(t *testing.T) {
 			`, "", Configuration{},
 		))
 	})
-
 }
 
 var expectedMyHeroPlan = &SynchronousResponsePlan{
@@ -311,9 +333,21 @@ var expectedMyHeroPlan = &SynchronousResponsePlan{
 									Path: []string{"name"},
 								},
 								Position: resolve.Position{
-									Line:   4,
-									Column: 7,
+									Line:   0,
+									Column: 0,
 								},
+								OnTypeName: []byte("Human"),
+							},
+							{
+								Name: []byte("name"),
+								Value: &resolve.String{
+									Path: []string{"name"},
+								},
+								Position: resolve.Position{
+									Line:   0,
+									Column: 0,
+								},
+								OnTypeName: []byte("Droid"),
 							},
 						},
 					},
@@ -344,9 +378,21 @@ var expectedMyHeroPlanWithFragment = &SynchronousResponsePlan{
 									Path: []string{"name"},
 								},
 								Position: resolve.Position{
-									Line:   3,
-									Column: 6,
+									Line:   0,
+									Column: 0,
 								},
+								OnTypeName: []byte("Human"),
+							},
+							{
+								Name: []byte("name"),
+								Value: &resolve.String{
+									Path: []string{"name"},
+								},
+								Position: resolve.Position{
+									Line:   0,
+									Column: 0,
+								},
+								OnTypeName: []byte("Droid"),
 							},
 						},
 					},

--- a/pkg/execution/datasource_http_json_test.go
+++ b/pkg/execution/datasource_http_json_test.go
@@ -604,17 +604,6 @@ func TestHttpJsonDataSourcePlanner_Plan(t *testing.T) {
 											},
 										},
 										{
-											Name: []byte("name"),
-											Value: &Value{
-												DataResolvingConfig: DataResolvingConfig{
-													PathSelector: datasource.PathSelector{
-														Path: "name",
-													},
-												},
-												ValueType: StringValueType,
-											},
-										},
-										{
 											Name: []byte("successField"),
 											Skip: &IfNotEqual{
 												Left: &datasource.ObjectVariableArgument{
@@ -656,6 +645,48 @@ func TestHttpJsonDataSourcePlanner_Plan(t *testing.T) {
 												ValueType: StringValueType,
 											},
 										},
+										{
+											Name: []byte("name"),
+											Skip: &IfNotEqual{
+												Left: &datasource.ObjectVariableArgument{
+													PathSelector: datasource.PathSelector{
+														Path: "__typename",
+													},
+												},
+												Right: &datasource.StaticVariableArgument{
+													Value: []byte("SuccessInterface"),
+												},
+											},
+											Value: &Value{
+												DataResolvingConfig: DataResolvingConfig{
+													PathSelector: datasource.PathSelector{
+														Path: "name",
+													},
+												},
+												ValueType: StringValueType,
+											},
+										},
+										{
+											Name: []byte("name"),
+											Skip: &IfNotEqual{
+												Left: &datasource.ObjectVariableArgument{
+													PathSelector: datasource.PathSelector{
+														Path: "__typename",
+													},
+												},
+												Right: &datasource.StaticVariableArgument{
+													Value: []byte("ErrorInterface"),
+												},
+											},
+											Value: &Value{
+												DataResolvingConfig: DataResolvingConfig{
+													PathSelector: datasource.PathSelector{
+														Path: "name",
+													},
+												},
+												ValueType: StringValueType,
+											},
+										},
 									},
 								},
 							},
@@ -668,7 +699,6 @@ func TestHttpJsonDataSourcePlanner_Plan(t *testing.T) {
 }
 
 func TestHttpJsonDataSource_Resolve(t *testing.T) {
-
 	test := func(serverStatusCode int, typeNameDefinition, wantTypeName string) func(t *testing.T) {
 		return func(t *testing.T) {
 			fakeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/graphql/execution_engine_test.go
+++ b/pkg/graphql/execution_engine_test.go
@@ -128,7 +128,7 @@ func TestExecutionEngine_ExecuteWithOptions(t *testing.T) {
 			expectedHost:     "example.com",
 			expectedPath:     "/",
 			expectedBody:     "",
-			sendResponseBody: `{"hero": {"name": "Luke Skywalker"}}`,
+			sendResponseBody: `{"hero": {"__typename": "Human", "name": "Luke Skywalker"}}`,
 			sendStatusCode:   200,
 		}),
 		expectedResponse: `{"data":{"hero":{"name":"Luke Skywalker"}}}`,
@@ -144,7 +144,7 @@ func TestExecutionEngine_ExecuteWithOptions(t *testing.T) {
 			expectedHost:     "example.com",
 			expectedPath:     "/",
 			expectedBody:     "",
-			sendResponseBody: `{"hero": {"name": "Luke Skywalker"}}`,
+			sendResponseBody: `{"hero": {"__typename": "Human", "name": "Luke Skywalker"}}`,
 			sendStatusCode:   200,
 		}),
 		expectedResponse: "",
@@ -158,7 +158,7 @@ func TestExecutionEngine_ExecuteWithOptions(t *testing.T) {
 			expectedHost:     "example.com",
 			expectedPath:     "/",
 			expectedBody:     "",
-			sendResponseBody: `{"data":{"hero":{"name":"Luke Skywalker"}}}`,
+			sendResponseBody: `{"data":{"hero":{"__typename": "Human", "name":"Luke Skywalker"}}}`,
 			sendStatusCode:   200,
 		}),
 		expectedResponse: `{"data":{"hero":{"name":"Luke Skywalker"}}}`,
@@ -176,7 +176,7 @@ func TestExecutionEngine_ExecuteWithOptions(t *testing.T) {
 			expectedHost:     "example.com",
 			expectedPath:     "/",
 			expectedBody:     "",
-			sendResponseBody: `{"data":{"hero":{"name":"Luke Skywalker"}}}`,
+			sendResponseBody: `{"data":{"hero":{"__typename": "Human", "name":"Luke Skywalker"}}}`,
 			sendStatusCode:   200,
 		}),
 		expectedResponse: `{"data":{"hero":{"name":"Luke Skywalker"}}}`,
@@ -190,7 +190,7 @@ func TestExecutionEngine_ExecuteWithOptions(t *testing.T) {
 			expectedHost:     "example.com",
 			expectedPath:     "/",
 			expectedBody:     "",
-			sendResponseBody: `{"data":{"droid":{"name":"R2D2"}}}`,
+			sendResponseBody: `{"data":{"__typename": "Droid", "droid":{"name":"R2D2"}}}`,
 			sendStatusCode:   200,
 		}),
 		preExecutionTasks: normalizeAndValidatePreExecutionTasks,
@@ -205,7 +205,7 @@ func TestExecutionEngine_ExecuteWithOptions(t *testing.T) {
 			expectedHost:     "example.com",
 			expectedPath:     "/",
 			expectedBody:     "",
-			sendResponseBody: `{"data":{"droid":{"name":"R2D2"}}}`,
+			sendResponseBody: `{"data":{"__typename": "Droid", "droid":{"name":"R2D2"}}}`,
 			sendStatusCode:   200,
 		}),
 		preExecutionTasks: normalizeAndValidatePreExecutionTasks,
@@ -377,7 +377,6 @@ func heroWithArgumentSchema(t *testing.T) *Schema {
 }
 
 func TestExampleExecutionEngine_Concatenation(t *testing.T) {
-
 	schema, err := NewSchemaFromString(`
 		schema { query: Query }
 		type Query { friend: Friend }
@@ -454,7 +453,6 @@ func TestExampleExecutionEngine_Concatenation(t *testing.T) {
 }
 
 func BenchmarkExecutionEngine(b *testing.B) {
-
 	newEngine := func() *ExecutionEngine {
 		schema, err := NewSchemaFromString(`type Query { hello: String}`)
 		assert.NoError(b, err)

--- a/pkg/graphql/execution_engine_v2.go
+++ b/pkg/graphql/execution_engine_v2.go
@@ -272,7 +272,6 @@ func (e *ExecutionEngineV2) Execute(ctx context.Context, operation *Request, wri
 }
 
 func (e *ExecutionEngineV2) getCachedPlan(ctx *internalExecutionContext, operation, definition *ast.Document, operationName string, report *operationreport.Report) plan.Plan {
-
 	hash := pool.Hash64.Get()
 	hash.Reset()
 	defer pool.Hash64.Put(hash)

--- a/pkg/graphql/federationtesting/federation_intergation_test.go
+++ b/pkg/graphql/federationtesting/federation_intergation_test.go
@@ -97,7 +97,7 @@ func TestFederationIntegrationTest(t *testing.T) {
 
 	t.Run("interface query", func(t *testing.T) {
 		resp := gqlClient.Query(ctx, setup.gatewayServer.URL, path.Join("testdata", "queries/interface.query"), nil, t)
-		assert.Equal(t, `{"data":{"me":{"username":"Me","history":[{"wallet":{"amount":123,"specialField1":"some special value 1"}},{"rating":5},{"wallet":{"amount":123,"specialField2":"some special value 2"}}]}}}`, string(resp))
+		assert.Equal(t, `{"data":{"me":{"username":"Me","history":[{"wallet":{"specialField1":"some special value 1","amount":123}},{"rating":5},{"wallet":{"specialField2":"some special value 2","amount":123}}]}}}`, string(resp))
 	})
 
 	t.Run("subscription query through WebSocket transport", func(t *testing.T) {

--- a/pkg/graphql/normalization_test.go
+++ b/pkg/graphql/normalization_test.go
@@ -39,7 +39,12 @@ func TestRequest_Normalize(t *testing.T) {
 
 		normalizedOperation := `query Fragments($droidID: ID!){
     hero {
-        name
+        ... on Human {
+            name
+        }
+        ... on Droid {
+            name
+        }
     }
     droid(id: $droidID){
         name


### PR DESCRIPTION
This PR adds the three operation normalization passes outlined in #328
to support abstract field federation. The new passes 1) "expand" inline
fragments with interface type conditions into inline fragments with
concrete type conditions, 2) "expand" interface selections to selections
that have inline fragments with the corresponding concrete types, and 3)
eliminate invalid inline fragments as the result of passes (1) and (2).
These passes run after fragment inlining but before inline fragment
merging. In the code I note that we may also want to implement merging
of inline fragment siblings that match.

A lot of tests needed to be updated due to these changes. The REST and
JSON data source tests were updated, but it isn't clear to me if
existing REST and JSON datasources will be compatible with these
changes; they need to return the appropriate "__typename" in responses
(since resolver fields now have OnTypeName conditions). Guidance on this
topic would be appreciated.

I also updated the ValidateByFieldList function to "expand" interface
types used in block and allow conditions to the corresponding concrete
types. This is what I'd expect (if Character "name" isn't allowed, then
Human "name" shouldn't be allowed either), but I could be mistaken about
the exact use of this function.

Depends on #336. (This is a stacked PR; the parent PR is expected to be
merged into master, followed by this PR, instead of merging this PR into
the parent PR directly.)