### PR TITLE
Fix required fields skipped in output.

### DIFF
--- a/pkg/astnormalization/inline_fragment_invalid_deletion.go
+++ b/pkg/astnormalization/inline_fragment_invalid_deletion.go
@@ -37,6 +37,12 @@ func (d *deleteInvalidInlineFragmentsVisitor) EnterSelectionSet(ref int) {
 
 		inlineFragment := d.operation.Selections[selections[index]].Ref
 
+		// Delete empty inline fragments
+		if !d.operation.InlineFragments[inlineFragment].HasSelections {
+			d.operation.RemoveFromSelectionSet(ref, index)
+			continue
+		}
+
 		typeName := d.operation.InlineFragmentTypeConditionName(inlineFragment)
 
 		node, exists := d.definition.Index.FirstNonExtensionNodeByNameBytes(typeName)

--- a/pkg/astnormalization/inline_fragment_invalid_deletion_test.go
+++ b/pkg/astnormalization/inline_fragment_invalid_deletion_test.go
@@ -3,7 +3,7 @@ package astnormalization
 import "testing"
 
 func TestDeleteInvalidInlineFragments(t *testing.T) {
-	t.Run("simple", func(t *testing.T) {
+	t.Run("incompatible type", func(t *testing.T) {
 		run(deleteInvalidInlineFragments, testDefinition, `
 					query testQuery {
 						dog {
@@ -13,6 +13,25 @@ func TestDeleteInvalidInlineFragments(t *testing.T) {
 							... on Cat {
 								meowVolume
 							}
+						}
+					}`,
+			`
+					query testQuery {
+						dog {
+							... on Dog {
+								barkVolume
+							}
+						}
+					}`)
+	})
+	t.Run("empty selection", func(t *testing.T) {
+		run(deleteInvalidInlineFragments, testDefinition, `
+					query testQuery {
+						dog {
+							... on Dog {
+								barkVolume
+							}
+							... on Dog {}
 						}
 					}`,
 			`


### PR DESCRIPTION
Fixes #335.

This PR fixes the case where a required field is present in *some*
fragment but a field in a different fragment requires the field, so the
field is added to the second fragment and entirely skipped in the
response.

The fix required tracking skipped fields by type in addition to path.
Also, it's possible a parent fetch already fetched the required field.
During federation this can cause a fragment selection to be emtpy. I've
updated the deleteInvalidInlineFragments normalization function to also
delete empty inline fragments.

This issue isn't specific to interface federation, but that's when it's
most likely to occur, so I've stacked the PR on top of the abstract
field federation PR, #5.

Depends on #5.